### PR TITLE
ci(ryo-cho): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/ryo-cho.yml
+++ b/.github/workflows/ryo-cho.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "*/5 * * * *"
 
+permissions:
+  contents: read
+
 jobs:
   ryu-cho:
     name: Ryu Cho


### PR DESCRIPTION
The Ryu-Cho-style translation-sync workflow uses a separate PAT for any issue/PR writes against `docs-pt`, so the default `GITHUB_TOKEN` isn't exercised on the write path. Workflow-level `contents: read` is the appropriate cap.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.